### PR TITLE
Added support for absolute paths in annotations. You can also pass a fun...

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ Type: `Boolean`
 
 Whether to just continue instead of emitting an error if circular dependencies are detected (defaults to ```false```).
 
+#### options.resolvePath
+Type: `Function`
+
+This function allows to override default file path resolver.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,10 @@ function resolveDependencies(config) {
 	var defaults = {
 			pattern: /\* @requires [\s-]*(.*\.js)/g,
 			log: false,
-			ignoreCircularDependencies: false
+			ignoreCircularDependencies: false,
+			resolvePath: function(match, targetFile) {
+				return path.join(path.dirname(targetFile.path), match);
+			}
 		},
 		stream,
 		dag = new DAG(),
@@ -39,7 +42,7 @@ function resolveDependencies(config) {
 			content = targetFile.contents.toString('utf8');
 
 			while (match = pattern.exec(content)) {
-				filePath = path.join(path.dirname(targetFile.path), match[1]);
+				filePath = config.resolvePath(match[1], targetFile);
 
 				// Check for circular dependencies
 				try {

--- a/test/expected/main2.js
+++ b/test/expected/main2.js
@@ -1,0 +1,6 @@
+console.log('test2.js');
+
+/**
+ * @requires test/test2.js
+ */
+console.log('main2.js');

--- a/test/fixtures/main2.js
+++ b/test/fixtures/main2.js
@@ -1,0 +1,4 @@
+/**
+ * @requires test/test2.js
+ */
+console.log('main2.js');

--- a/test/fixtures/test/test2.js
+++ b/test/fixtures/test/test2.js
@@ -1,0 +1,1 @@
+console.log('test2.js');

--- a/test/main.js
+++ b/test/main.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
 	fs = require('fs'),
+	path = require('path'),
 	es = require('event-stream'),
 	assert = require('assert'),
 	concat = require('gulp-concat'),
@@ -18,6 +19,34 @@ describe('gulp-resolve-dependencies', function() {
 				);
 
 				fs.unlinkSync(__dirname + '/results/main.js');
+				fs.rmdirSync(__dirname + '/results/');
+
+				done();
+			}));
+	});
+
+	it('should use resolvePath and generate concatenated JS file', function(done) {
+		function toAbsolutePath(match, targetFile) {
+			var absolutePath = path.join(__dirname, 'fixtures', match);
+			return absolutePath;
+		}
+
+		gulp.src(__dirname + '/fixtures/main2.js')
+			.pipe(resolveDependencies({
+				pattern: /\* @requires [\s-]*(.*)/g,
+				resolvePath: toAbsolutePath
+			}))
+			.pipe(concat('main2.js'))
+			.pipe(gulp.dest(__dirname + '/results/'))
+			.pipe(es.wait(function() {
+				var expected = fs.readFileSync(__dirname + '/expected/main2.js', 'utf8');
+
+				assert.equal(
+					fs.readFileSync(__dirname + '/results/main2.js', 'utf8'),
+					expected
+				);
+
+				fs.unlinkSync(__dirname + '/results/main2.js');
 				fs.rmdirSync(__dirname + '/results/');
 
 				done();


### PR DESCRIPTION
Added support for absolute paths in annotations. You can also pass a function in `options.preprocessor` to modify the contents of file before it is searched for dependencies. `preprocessor` is needed for existing project that I'm working on which has relative paths that are dot-separated. Using preprocessor I can transform paths like `com.example.ClassName` into `com/example/ClassName.js`