### PR TITLE
Handle files with relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function resolveDependencies(config) {
 			log: false,
 			ignoreCircularDependencies: false,
 			resolvePath: function(match, targetFile) {
-				return path.join(path.dirname(targetFile.path), match);
+				return path.join(path.dirname(path.resolve(targetFile.path)), match);
 			}
 		},
 		stream,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "event-stream": "^3.2.2",
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.3",
+    "gulp-file": "^0.3.0",
     "gulp-tap": "^0.1.3",
     "mocha": "^2.1.0"
   }

--- a/test/expected/relative.js
+++ b/test/expected/relative.js
@@ -1,0 +1,22 @@
+console.log('lib2.js');
+
+/**
+ * @requires lib2.js/lib2.js
+ */
+console.log('lib.js');
+
+/**
+ * @requires ../libs/lib.js
+ * @requires ../libs/lib2.js/lib2.js
+ */
+console.log('test.js');
+
+/**
+ * @requires test/test.js
+ */
+console.log('main.js');
+
+/**
+ * @requires main.js
+ */
+console.log('relative.js');

--- a/test/main.js
+++ b/test/main.js
@@ -8,6 +8,19 @@ var gulp = require('gulp'),
 	tap = require('gulp-tap'),
 	resolveDependencies = require('../');
 
+function assertFilesEqual(file) {
+	var result = path.join(__dirname, 'results', file);
+	var expected = path.join(__dirname, 'expected', file);
+
+	assert.equal(
+		fs.readFileSync(result, 'utf8'),
+		fs.readFileSync(expected, 'utf8')
+	);
+
+	fs.unlinkSync(result);
+	fs.rmdirSync(__dirname + '/results/');
+}
+
 describe('gulp-resolve-dependencies', function() {
 	it('should generate concatenated JS file', function(done) {
 		gulp.src(__dirname + '/fixtures/main.js')
@@ -15,14 +28,7 @@ describe('gulp-resolve-dependencies', function() {
 			.pipe(concat('main.js'))
 			.pipe(gulp.dest(__dirname + '/results/'))
 			.pipe(es.wait(function() {
-				assert.equal(
-					fs.readFileSync(__dirname + '/results/main.js', 'utf8'),
-					fs.readFileSync(__dirname + '/expected/main.js', 'utf8')
-				);
-
-				fs.unlinkSync(__dirname + '/results/main.js');
-				fs.rmdirSync(__dirname + '/results/');
-
+				assertFilesEqual('main.js');
 				done();
 			}));
 	});
@@ -36,14 +42,7 @@ describe('gulp-resolve-dependencies', function() {
 			.pipe(concat('relative.js'))
 			.pipe(gulp.dest(__dirname + '/results/'))
 			.pipe(es.wait(function() {
-				assert.equal(
-					fs.readFileSync(__dirname + '/results/relative.js', 'utf8'),
-					fs.readFileSync(__dirname + '/expected/relative.js', 'utf8')
-				);
-
-				fs.unlinkSync(__dirname + '/results/relative.js');
-				fs.rmdirSync(__dirname + '/results/');
-
+				assertFilesEqual('relative.js');
 				done();
 			}));
 	});
@@ -64,14 +63,7 @@ describe('gulp-resolve-dependencies', function() {
 			.pipe(concat('resolvepath.js'))
 			.pipe(gulp.dest(__dirname + '/results/'))
 			.pipe(es.wait(function() {
-				assert.equal(
-					fs.readFileSync(__dirname + '/results/resolvepath.js', 'utf8'),
-					fs.readFileSync(__dirname + '/expected/resolvepath.js', 'utf8')
-				);
-
-				fs.unlinkSync(__dirname + '/results/resolvepath.js');
-				fs.rmdirSync(__dirname + '/results/');
-
+				assertFilesEqual('resolvepath.js');
 				done();
 			}));
 	});

--- a/test/main.js
+++ b/test/main.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp'),
 	fs = require('fs'),
+	file = require('gulp-file'),
 	path = require('path'),
 	es = require('event-stream'),
 	assert = require('assert'),
@@ -20,6 +21,27 @@ describe('gulp-resolve-dependencies', function() {
 				);
 
 				fs.unlinkSync(__dirname + '/results/main.js');
+				fs.rmdirSync(__dirname + '/results/');
+
+				done();
+			}));
+	});
+
+	it('should handle relative file paths', function(done) {
+
+		gulp.src(__dirname + '/fixtures/main.js')
+			// Add a new file
+			.pipe(file('test/fixtures/relative.js', ['/**\n', ' * @requires main.js\n', ' */\n', 'console.log(\'relative.js\');\n'].join('')))
+			.pipe(resolveDependencies())
+			.pipe(concat('relative.js'))
+			.pipe(gulp.dest(__dirname + '/results/'))
+			.pipe(es.wait(function() {
+				assert.equal(
+					fs.readFileSync(__dirname + '/results/relative.js', 'utf8'),
+					fs.readFileSync(__dirname + '/expected/relative.js', 'utf8')
+				);
+
+				fs.unlinkSync(__dirname + '/results/relative.js');
 				fs.rmdirSync(__dirname + '/results/');
 
 				done();


### PR DESCRIPTION
Changes the default resolvePath method to resolve the absolute file path before using it. This enables a mix of relative and absolute file paths to work together.

This fixes #15.
