### PR TITLE
Replacing deprecated dependency ‘gulp-util’ with suitable alternatives.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,9 @@
 
 var fs = require('fs'),
 	path = require('path'),
-	gutil = require('gulp-util'),
+	Vinyl = require('vinyl'),
+	Log = require('fancy-log'),
+	AnsiColors = require('ansi-colors'),
 	_ = require('lodash'),
 	Stream = require('stream'),
 	DAG = require('dag');
@@ -64,7 +66,7 @@ function resolveDependencies(config) {
 				}
 
 				// Create new file
-				file = new gutil.File({
+				file = new Vinyl({
 					base: targetFile.base,
 					path: filePath,
 					contents: fs.readFileSync(filePath),
@@ -122,7 +124,7 @@ function resolveDependencies(config) {
 
 	stream._flush = function(cb) {
 		if (config.log) {
-			gutil.log('[' + gutil.colors.green(PLUGIN_NAME) + '] Files returned to stream:', filesReturned);
+			Log('[' + AnsiColors.green(PLUGIN_NAME) + '] Files returned to stream:', filesReturned);
 		}
 
 		cb();

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
     "sprockets"
   ],
   "dependencies": {
+    "ansi-colors": "^2.0.2",
     "dag": "0.0.1",
-    "gulp-util": "^3.0.3",
-    "lodash": "^3.1.0"
+    "fancy-log": "^1.3.0",
+    "lodash": "^3.1.0",
+    "vinyl": "^2.2.0"
   },
   "devDependencies": {
     "event-stream": "^3.2.2",


### PR DESCRIPTION
This should still work fine in Gulp 3.x and won't break in Gulp 4.