### PR TITLE
add exclude and include options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ Type: `Boolean`
 
 Whether to just continue instead of emitting an error if circular dependencies are detected (defaults to ```false```).
 
+#### options.include
+Type: `Array`
+
+Only dependencies matching this array of absolute paths will be included (defaults to ```[]```).
+
+#### options.exclude
+Type: `Array`
+
+Dependencies matching this array of absolute paths will be excluded (defaults to ```[]```).
+
 
 ## Contributors
 

--- a/index.js
+++ b/index.js
@@ -51,14 +51,14 @@ function resolveDependencies(config) {
 			while (match = pattern.exec(content)) {
 				filePath = config.resolvePath(match[1], targetFile);
         
-        // Ignore falsy returns
+				// Ignore falsy returns
 				if (!filePath) {
 					if (config.log) {
 						Log('[' + AnsiColors.green(PLUGIN_NAME) + '] Ignored', match[1]);
 					}
 
-          continue;
-        }
+					continue;
+				}
 
 				// Check include
 				if (config.include && config.include.length !== 0 && !config.include.some(_ => minimatch(filePath, _))) {

--- a/test/expected/mainexclude.js
+++ b/test/expected/mainexclude.js
@@ -1,0 +1,10 @@
+/**
+ * @requires ../libs/lib.js
+ * @requires ../libs/lib2.js/lib2.js
+ */
+console.log('test.js');
+
+/**
+ * @requires test/test.js
+ */
+console.log('main.js');

--- a/test/expected/maininclude.js
+++ b/test/expected/maininclude.js
@@ -1,0 +1,10 @@
+/**
+ * @requires ../libs/lib.js
+ * @requires ../libs/lib2.js/lib2.js
+ */
+console.log('test.js');
+
+/**
+ * @requires test/test.js
+ */
+console.log('main.js');

--- a/test/main.js
+++ b/test/main.js
@@ -89,4 +89,30 @@ describe('gulp-resolve-dependencies', function() {
 				done();
 			});
 	});
+
+	it('should exclude depencencies from fixtures/libs', function(done) {
+		gulp.src(__dirname + '/fixtures/main.js')
+			.pipe(resolveDependencies({
+				exclude: [path.resolve(__dirname, "fixtures/libs/**/*")]
+			}))
+			.pipe(concat('mainexclude.js'))
+			.pipe(gulp.dest(__dirname + '/results/'))
+			.pipe(es.wait(function() {
+				assertFilesEqual('mainexclude.js');
+				done();
+			}));
+	});
+
+	it('should only include depencencies from fixtures/test', function(done) {
+		gulp.src(__dirname + '/fixtures/main.js')
+			.pipe(resolveDependencies({
+				include: [path.resolve(__dirname, "fixtures/test/**/*")]
+			}))
+			.pipe(concat('maininclude.js'))
+			.pipe(gulp.dest(__dirname + '/results/'))
+			.pipe(es.wait(function() {
+				assertFilesEqual('maininclude.js');
+				done();
+			}));
+	});
 });


### PR DESCRIPTION
I added two new options for filtering dependencies returned by gulp-resolve-dependencies and wrote tests.

With **exclude** it is possible to make gulp-resolve-dependencies ignore dependencies from certain directories:

```js
it('should exclude depencencies from fixtures/libs', function(done) {
    gulp.src(__dirname + '/fixtures/main.js')
        .pipe(resolveDependencies({
            exclude: [path.resolve(__dirname, "fixtures/libs/**/*")]
        }))
        .pipe(concat('mainexclude.js'))
        .pipe(gulp.dest(__dirname + '/results/'))
        .pipe(es.wait(function() {
            assertFilesEqual('mainexclude.js');
            done();
        }));
});
```

With **include** it is possible to make gulp-resolve-dependencies return only dependencies from certain directories:

```js
it('should only include depencencies from fixtures/test', function(done) {
    gulp.src(__dirname + '/fixtures/main.js')
        .pipe(resolveDependencies({
            include: [path.resolve(__dirname, "fixtures/test/**/*")]
        }))
        .pipe(concat('maininclude.js'))
        .pipe(gulp.dest(__dirname + '/results/'))
        .pipe(es.wait(function() {
            assertFilesEqual('maininclude.js');
            done();
        }));
});
```

Those paths are tested with:

```js
filePath = config.resolvePath(...)
minimatch(filePath, excludedPath/includedPath)
```

When the **log** option is set, it will output included or excluded dependencies to console:

```js
Log('[' + AnsiColors.green(PLUGIN_NAME) + '] File not included:', filePath);
Log('[' + AnsiColors.green(PLUGIN_NAME) + '] File excluded:', filePath);
```